### PR TITLE
fix: mobile pagination overflow and update env example format

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 NEXT_PUBLIC_SUPABASE_URL=https://<your-project>.supabase.co
-NEXT_PUBLIC_SUPABASE_ANON_KEY=<your-supabase-anon-key>
+NEXT_PUBLIC_SUPABASE_ANON_KEY=sb-publishable-<your-anon-key>

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -797,66 +797,71 @@ export default function AdminPage() {
                     })}
 
                     {totalApprovedPages > 1 && (
-                      <Pagination className="pt-2">
-                        <PaginationContent>
-                          <PaginationItem>
-                            <PaginationPrevious
-                              href="#"
-                              onClick={(e) => {
-                                e.preventDefault()
-                                if (currentApprovedPage > 1) handleApprovedPageChange(currentApprovedPage - 1)
-                              }}
-                              className={currentApprovedPage <= 1 ? "pointer-events-none opacity-50" : ""}
-                            />
-                          </PaginationItem>
+                      <div className="overflow-x-auto -mx-1 px-1">
+                        <Pagination className="pt-2 w-max sm:w-full mx-auto">
+                          <PaginationContent className="flex-nowrap gap-0 sm:gap-1">
+                            <PaginationItem>
+                              <PaginationPrevious
+                                href="#"
+                                onClick={(e) => {
+                                  e.preventDefault()
+                                  if (currentApprovedPage > 1) handleApprovedPageChange(currentApprovedPage - 1)
+                                }}
+                                className={`${currentApprovedPage <= 1 ? "pointer-events-none opacity-50" : ""} [&>span]:hidden sm:[&>span]:inline px-1.5 sm:px-2.5`}
+                              />
+                            </PaginationItem>
 
-                          {Array.from({ length: totalApprovedPages }, (_, i) => i + 1)
-                            .filter((page) => {
-                              if (totalApprovedPages <= 7) return true
-                              if (page === 1 || page === totalApprovedPages) return true
-                              if (Math.abs(page - currentApprovedPage) <= 1) return true
-                              return false
-                            })
-                            .map((page, index, arr) => {
-                              const showEllipsisBefore = index > 0 && page - arr[index - 1] > 1
+                            {Array.from({ length: totalApprovedPages }, (_, i) => i + 1)
+                              .filter((page) => {
+                                if (totalApprovedPages <= 5) return true
+                                if (page === 1 || page === totalApprovedPages) return true
+                                if (Math.abs(page - currentApprovedPage) <= 1) return true
+                                return false
+                              })
+                              .map((page, index, arr) => {
+                                const showEllipsisBefore = index > 0 && page - arr[index - 1] > 1
 
-                              return (
-                                <span key={page} className="contents">
-                                  {showEllipsisBefore && (
-                                    <PaginationItem>
-                                      <PaginationEllipsis />
-                                    </PaginationItem>
-                                  )}
-                                  <PaginationItem>
-                                    <PaginationLink
-                                      href="#"
-                                      isActive={page === currentApprovedPage}
-                                      onClick={(e) => {
-                                        e.preventDefault()
-                                        handleApprovedPageChange(page)
-                                      }}
+                                return (
+                                  <span key={page} className="contents">
+                                    {showEllipsisBefore && (
+                                      <PaginationItem className="hidden sm:list-item">
+                                        <PaginationEllipsis />
+                                      </PaginationItem>
+                                    )}
+                                    <PaginationItem
+                                      className={page !== currentApprovedPage && Math.abs(page - currentApprovedPage) > 1 ? "hidden sm:list-item" : ""}
                                     >
-                                      {page}
-                                    </PaginationLink>
-                                  </PaginationItem>
-                                </span>
-                              )
-                            })}
+                                      <PaginationLink
+                                        href="#"
+                                        isActive={page === currentApprovedPage}
+                                        onClick={(e) => {
+                                          e.preventDefault()
+                                          handleApprovedPageChange(page)
+                                        }}
+                                        className="h-8 w-8 sm:h-9 sm:w-9"
+                                      >
+                                        {page}
+                                      </PaginationLink>
+                                    </PaginationItem>
+                                  </span>
+                                )
+                              })}
 
-                          <PaginationItem>
-                            <PaginationNext
-                              href="#"
-                              onClick={(e) => {
-                                e.preventDefault()
-                                if (currentApprovedPage < totalApprovedPages) {
-                                  handleApprovedPageChange(currentApprovedPage + 1)
-                                }
-                              }}
-                              className={currentApprovedPage >= totalApprovedPages ? "pointer-events-none opacity-50" : ""}
-                            />
-                          </PaginationItem>
-                        </PaginationContent>
-                      </Pagination>
+                            <PaginationItem>
+                              <PaginationNext
+                                href="#"
+                                onClick={(e) => {
+                                  e.preventDefault()
+                                  if (currentApprovedPage < totalApprovedPages) {
+                                    handleApprovedPageChange(currentApprovedPage + 1)
+                                  }
+                                }}
+                                className={`${currentApprovedPage >= totalApprovedPages ? "pointer-events-none opacity-50" : ""} [&>span]:hidden sm:[&>span]:inline px-1.5 sm:px-2.5`}
+                              />
+                            </PaginationItem>
+                          </PaginationContent>
+                        </Pagination>
+                      </div>
                     )}
                   </div>
                 ) : (


### PR DESCRIPTION
## Summary

Fixes the approved sessions pagination overflowing on mobile and improves the .env.example with a realistic dummy key format.

## Changes

### Mobile Pagination Fix
- Added `overflow-x-auto` wrapper to allow horizontal scroll if needed.
- Previous/Next buttons show icons only on mobile (`[&>span]:hidden sm:[&>span]:inline`), full text on desktop.
- Reduced gaps (`gap-0 sm:gap-1`), tighter padding (`px-1.5 sm:px-2.5`), smaller page button sizes (`h-8 w-8 sm:h-9 sm:w-9`).
- Non-adjacent page numbers hidden on mobile to reduce clutter.

### .env.example
- Changed key placeholder from `<your-supabase-anon-key>` to `sb-publishable-<your-anon-key>` for clarity.